### PR TITLE
fix import path of share

### DIFF
--- a/projects/ngx-hotkeys/src/lib/services/ngx-hotkeys.service.ts
+++ b/projects/ngx-hotkeys/src/lib/services/ngx-hotkeys.service.ts
@@ -3,7 +3,7 @@ import { Observable, Subject, Subscription } from 'rxjs';
 
 import { Hotkey, HotkeyOptions } from '../interfaces';
 import { HOTKEY_OPTIONS } from '../token';
-import { share } from 'rxjs/internal/operators';
+import { share } from 'rxjs/operators';
 import { EventManager } from '@angular/platform-browser';
 import { DOCUMENT } from '@angular/common';
 


### PR DESCRIPTION
> Warning: /Users/fxck/www/zerops/node_modules/@balticcode/ngx-hotkeys/fesm2015/balticcode-ngx-hotkeys.js depends on 'rxjs/internal/operators'.  CommonJS or AMD dependencies can cause optimization bailouts.
For more info see: https://angular.io/guide/build#configuring-commonjs-dependencies